### PR TITLE
[ENG-1182] Adapt notebooks to use get_or_create_prompt()

### DIFF
--- a/evaluation/python/Context relevancy with Ragas.ipynb
+++ b/evaluation/python/Context relevancy with Ragas.ipynb
@@ -112,7 +112,7 @@
     "    }\n",
     "]\n",
     "\n",
-    "prompt = literal_client.api.create_prompt(name=PROMPT_NAME, template_messages=template_messages)"
+    "prompt = literal_client.api.get_or_create_prompt(name=PROMPT_NAME, template_messages=template_messages)"
    ]
   },
   {

--- a/evaluation/python/Evaluate user satisfaction.ipynb
+++ b/evaluation/python/Evaluate user satisfaction.ipynb
@@ -245,7 +245,7 @@
     "    }\n",
     "]\n",
     "\n",
-    "prompt = literal_client.api.create_prompt(name=\"Satisfaction Evaluation prompt\", template_messages=template_messages)"
+    "prompt = literal_client.api.get_or_create_prompt(name=\"Satisfaction Evaluation prompt\", template_messages=template_messages)"
    ]
   },
   {


### PR DESCRIPTION
Remove use of deprecated API calls from our cookbooks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/literal-cookbook/3)
<!-- Reviewable:end -->
