### PR TITLE
fix: rename intermediary step expectedOutput to output

### DIFF
--- a/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
+++ b/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
@@ -246,7 +246,7 @@
     "contexts = []\n",
     "for item in items:\n",
     "    retrieve_step = next(step for step in item.intermediary_steps if step[\"name\"] == \"Retrieve\")\n",
-    "    contexts.append(retrieve_step[\"expectedOutput\"][\"documents\"][0])\n",
+    "    contexts.append(retrieve_step[\"output\"][\"documents\"][0])\n",
     "\n",
     "# Data samples, in the format expected by Ragas. No ground truth needed since we will evaluate context relevancy.\n",
     "data_samples = {\n",

--- a/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
+++ b/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "2570961b-b58d-43a4-b848-ef51acad468f",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "id": "05b8e2e1-7cc7-4673-b91a-1a55f5602aa5",
    "metadata": {},
    "outputs": [],

--- a/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
+++ b/python/context-relevancy-ragas/Context relevancy with Ragas.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "2570961b-b58d-43a4-b848-ef51acad468f",
    "metadata": {},
    "outputs": [],
@@ -66,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "05b8e2e1-7cc7-4673-b91a-1a55f5602aa5",
    "metadata": {},
    "outputs": [],
@@ -137,7 +137,7 @@
     "        results = collection.query(query_texts=[user_query], n_results=2)\n",
     "        step.output = results\n",
     "\n",
-    "    messages = prompt.format({\"context\": results[\"documents\"][0], \"question\": user_query})\n",
+    "    messages = prompt.format_messages(context=results[\"documents\"][0], question=user_query)\n",
     "    \n",
     "    completion = openai_client.chat.completions.create(\n",
     "        model=\"gpt-3.5-turbo\",\n",
@@ -468,7 +468,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We renamed a field in the intermediary steps in https://github.com/Chainlit/chainlit-cloud/pull/544. 

We need to adapt our cookbooks. 

The promptfoo cookbook uses the `DatasetItem.expectedOutput`, so no need for update. 

The change breaks compatibility with previous versions, but that's only with `DatasetItem.intermediarySteps` which I believe no one uses yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Chainlit/literal-cookbook/12)
<!-- Reviewable:end -->
